### PR TITLE
Chaning qc.planes to have 6 cols for panel ids

### DIFF
--- a/panel-qc-viewer/public/javascripts/all_panel_qc.js
+++ b/panel-qc-viewer/public/javascripts/all_panel_qc.js
@@ -1,5 +1,6 @@
 import { single_channel_issues } from './single_channel_issues.js'
 import { single_panel_issues, single_panel_issue_names } from './single_panel_issues.js'
+import { get_panels_in_plane } from './get_panels_in_plane.js'
 const single_ch_issues = single_channel_issues();
 const single_pan_issues = single_panel_issues();
 const single_pan_issue_names = single_panel_issue_names();
@@ -128,7 +129,7 @@ for (let i_issue = 0; i_issue < single_ch_issues.length; ++i_issue) {
     for (let i_plane = 0; i_plane < planes.length; i_plane++) {
 	n_issue[i_plane] = 0;
 	planes[i_plane] = allPlaneInfo[i_plane]['plane_id'];
-	let panels = allPlaneInfo[i_plane]['panel_ids']
+	let panels = get_panels_in_plane(allPlaneInfo[i_plane])
 	for (let i_panel = 0; i_panel < panels.length; ++i_panel){
 	    let panel_number = panels[i_panel];
 	    const panel_info = allPanelInfo[panel_num_map.get(panel_number)];
@@ -154,7 +155,7 @@ for (let i_issue = 0; i_issue < single_pan_issues.length; ++i_issue) {
     for (let i_plane = 0; i_plane < planes.length; i_plane++) {
 	vals[i_plane] = 0;
 	planes[i_plane] = allPlaneInfo[i_plane]['plane_id'];
-	let panels = allPlaneInfo[i_plane]['panel_ids']
+	let panels = get_panels_in_plane(allPlaneInfo[i_plane])
 
 	for (let i_panel = 0; i_panel < panels.length; ++i_panel){
 	    let panel_number = panels[i_panel];

--- a/panel-qc-viewer/public/javascripts/get_panels_in_plane.js
+++ b/panel-qc-viewer/public/javascripts/get_panels_in_plane.js
@@ -1,0 +1,31 @@
+export function get_panels_in_plane(plane_info) {
+
+    var panel_positions=['pos0', 'pos1', 'pos2', 'pos3', 'pos4', 'pos5']
+    var panels = Array();
+    for (let i_panel = 0; i_panel < panel_positions.length; ++i_panel) {
+	if (plane_info['panel_ids'].length>0) { // some planes have not been updated to the new 6-column format
+	    panels.push(plane_info['panel_ids'][i_panel]);
+	}
+	else {
+	    let panel_pos = panel_positions[i_panel]
+	    if (plane_info['panel_id_'+panel_pos] != null) {
+		panels.push(plane_info['panel_id_'+panel_pos]);
+	    }
+	}
+    }
+    return panels;
+}
+
+// true = 6-column format, false = 1-column format
+export function get_panels_col_format(plane_info) {
+
+    if (plane_info['panel_ids'].length>0) { // some planes have not been updated to the new 6-column format
+	return false;
+    }
+    else if (get_panels_in_plane(plane_info).length == 0) {
+	return false; // no panels in plane at all
+    }
+    else {
+	return true;
+    }
+}

--- a/panel-qc-viewer/public/javascripts/panel_qc_plot.js
+++ b/panel-qc-viewer/public/javascripts/panel_qc_plot.js
@@ -1,12 +1,15 @@
 import { single_channel_issues } from './single_channel_issues.js'
 import { single_panel_issues, single_panel_issue_names } from './single_panel_issues.js'
 
-export function plot_panel_qc(panel_info, straw_status_plot) {
+export function plot_panel_qc(panel_info, straw_status_plot, position="") {
 
     const single_ch_issues = single_channel_issues(); // the rest to be added
 
     var this_panel_issues = panel_info[0]
     var this_title = "Panel "+this_panel_issues["panel_id"];
+    if (position != "") {
+	this_title += " (" + position + ")";
+    }
 
     var all_wires = Array(96).fill(0)
     var wire_numbers = Array(96).fill(0)

--- a/panel-qc-viewer/public/javascripts/plane_qc.js
+++ b/panel-qc-viewer/public/javascripts/plane_qc.js
@@ -1,5 +1,6 @@
 import { plot_panel_qc } from './panel_qc_plot.js'
 import { draw_repairs_table } from './repairs_table.js'
+import { get_panels_in_plane, get_panels_col_format } from './get_panels_in_plane.js'
 const form = document.querySelector("form");
 const log = document.querySelector("#log");
 
@@ -22,14 +23,14 @@ showPlaneButton.addEventListener('click', async function () {
 	    output += " not found!";
 	}
 	else {
-	    var panels = Array(6).fill(0);
-	    for (let i_panel = 0; i_panel < 6; ++i_panel) {
-		panels[i_panel] = plane_info[0]['panel_ids'][i_panel];
+	    var panels = get_panels_in_plane(plane_info[0]);
+	    let six_col_format = get_panels_col_format(plane_info[0]);
+	    if (panels.length == 0) {
+		output += " no panels";
 	    }
 
-	    for (let i_panel = 0; i_panel < 6; ++i_panel) {
+	    for (let i_panel = 0; i_panel < panels.length; ++i_panel) {
 		var panel_number = panels[i_panel]
-		var this_title = "Panel "+panel_number.toString();
 		
 		const response = await fetch('getPanel/'+panel_number);
 		const panel_info = await response.json();
@@ -39,9 +40,20 @@ showPlaneButton.addEventListener('click', async function () {
 		    output += " not found!";
 		}
 		else {
+		    let position="";
+		    if (six_col_format) {
+			position = "pos " + i_panel;
+			if (i_panel % 2 == 0) {
+			    position += " = top";
+			}
+			else {
+			    position += " = bottom";
+			}
+			output += " (" + position + ")";
+		    }
 		    var plot_name = 'panel'+(i_panel+1).toString()+'_plot';
 		    var straw_status_plot = document.getElementById(plot_name);
-		    var returned_output = plot_panel_qc(panel_info, straw_status_plot);
+		    var returned_output = plot_panel_qc(panel_info, straw_status_plot, position);
 		    output += returned_output + "\n\n";
 		}
 	    }
@@ -60,14 +72,11 @@ showPlaneButton.addEventListener('click', async function () {
 	// Now do the panel repairs table
 //	var cols = ["panel_id", "date_uploaded", "comment", "column_changed", "old_value", "new_value"];
 
-	var panels = Array(6).fill(0);
-	for (let i_panel = 0; i_panel < 6; ++i_panel) {
-	    panels[i_panel] = plane_info[0]['panel_ids'][i_panel];
-	}
+	var panels = get_panels_in_plane(plane_info[0]);
+	let six_col_format = get_panels_col_format(plane_info[0]);
 
-	for (let i_panel = 0; i_panel < 6; ++i_panel) {
+	for (let i_panel = 0; i_panel < panels.length; ++i_panel) {
 	    var panel_number = panels[i_panel]
-	    var this_title = "Panel "+panel_number.toString();
 		
 	    const repairs_panel_table_response = await fetch('getPanelRepairs/'+panel_number);
 	    const repairs_panel_table_info = await repairs_panel_table_response.json();

--- a/python/create_update_qc_planes_table.py
+++ b/python/create_update_qc_planes_table.py
@@ -13,8 +13,10 @@ parser = argparse.ArgumentParser(
 
 parser.add_argument('--plane_id', required=True)
 parser.add_argument('--comment', required=True)
-parser.add_argument('--add_panels', nargs='*', help='Add these panels')
-parser.add_argument('--remove_panels', nargs='*', help='Remove these panels')
+parser.add_argument('--add_panels_in_order', nargs='*', help='Add panels in order (pos0, pos1, ..., pos5)')
+parser.add_argument('--panel_swap_out', nargs=1, help='Swap this panel in')
+parser.add_argument('--panel_swap_in', nargs=1, help='Swap this panel out')
+parser.add_argument('--panel_swap_pos', nargs=1, help='Position where panel was')
 parser.add_argument('--append', type=bool, default=False, help='Append SQL commands to previously created .sql file')
 
 args = parser.parse_args()
@@ -22,21 +24,30 @@ dict_args = vars(args) # convert to dictionary
 
 plane_id=args.plane_id
 
-panels_to_add=dict_args['add_panels']
-panels_to_remove=dict_args['remove_panels']
+panels_to_add=dict_args['add_panels_in_order']
+panel_swap_in=dict_args['panel_swap_in']
+panel_swap_out=dict_args['panel_swap_out']
+panel_swap_pos=dict_args['panel_swap_pos']
+#panels_to_remove=dict_args['remove_panels']
 comment=args.comment
 
-if panels_to_add==None:
+if panels_to_add!=None:
+    if (len(panels_to_add) != 6):
+        print("ERROR: We want to add all 6 panel_ids at once\n")
+        exit(1)
+else:
     panels_to_add=[]
-if panels_to_remove==None:
-    panels_to_remove=[]
+
+if not ((panel_swap_in!=None and panel_swap_out!=None and panel_swap_pos!=None) or (panel_swap_in==None and panel_swap_out==None and panel_swap_pos==None)):
+    print("ERROR: All of --panel_swap_in, --panel_swap_out, and --panel_swap_pos are required\n")
+    exit(1)
+
+#if panels_to_remove==None:
+#    panels_to_remove=[]
 
 # Check that number of added panels = number of removed panels
 # if (len(panels_to_add) != len(panels_to_remove)):
 #     # Now check if we are adding 6 panels (i.e. adding information for a new plane)
-#     if (len(panels_to_add) != 6):
-#         print("ERROR: Expected either (a) number of panels to add = number of panels to remove, or (b) number of panels to add = 6. Exiting...");
-#         exit(1)
 
 outfilename = '../sql/update_qc_planes_table.sql'#_'+str(plane_id)+'.sql';
 print("Creating " + outfilename + " for plane number " + str(plane_id) + "...");
@@ -45,19 +56,39 @@ opts='w'
 if args.append:
     opts = 'a'
 
-update_sql_file = open(outfilename, 'a')
+update_sql_file = open(outfilename, opts)
+
 
 # first get the old values from qc.planes and create a new row in repairs.planes
-update_sql_file.write("WITH old_values AS (SELECT plane_id,panel_ids from qc.planes WHERE plane_id="+str(plane_id)+") INSERT INTO repairs.planes(plane_id, old_value) SELECT plane_id,panel_ids FROM old_values;\n"); # insert the new repair row with the old values
+for pos,add in enumerate(panels_to_add): # want to add panel IDs in order in different columns
+#    print(pos,add)
+    column="panel_id_pos"+str(pos)
+    update_sql_file.write("WITH old_values AS (SELECT plane_id,"+column+" from qc.planes WHERE plane_id="+str(plane_id)+") INSERT INTO repairs.planes(plane_id, old_value) SELECT plane_id,"+column+" FROM old_values;\n"); # insert the new repair row with the old values
 
-# make changes to qc.planes
-update_sql_file.write("UPDATE qc.planes SET panel_ids=ARRAY_CAT(panel_ids, \'{" + ', '.join(panels_to_add) + "}\') where plane_id=" + str(plane_id) + ";\n");
-for rem in panels_to_remove: # have to remove elements one at a time in psql
-    update_sql_file.write("UPDATE qc.planes SET panel_ids=ARRAY_REMOVE(panel_ids, "+rem+") where plane_id=" + str(plane_id) + ";\n");
+    # make changes to qc.planes
+    update_sql_file.write("UPDATE qc.planes SET "+column+"="+add+" where plane_id=" + str(plane_id) + ";\n");
 
-# now update repairs table
-update_sql_file.write("UPDATE repairs.planes SET column_changed=\'plane_ids\',date_uploaded=\'"+date.today().strftime('%Y-%m-%d')+"\',comment=\'"+comment+"\' where repair_id=LASTVAL();\n") # now add the changed column and comment
-update_sql_file.write("WITH new_values AS (SELECT plane_id,panel_ids from qc.planes WHERE plane_id="+str(plane_id)+") UPDATE repairs.planes SET new_value=(SELECT panel_ids FROM new_values) WHERE repair_id=LASTVAL();\n"); # insert the new repair row with the old values
+    # now update repairs table
+    update_sql_file.write("UPDATE repairs.planes SET column_changed=\'"+column+"\',date_uploaded=\'"+date.today().strftime('%Y-%m-%d')+"\',comment=\'"+comment+"\' where repair_id=LASTVAL();\n") # now add the changed column and comment
+    update_sql_file.write("WITH new_values AS (SELECT plane_id,"+column+" from qc.planes WHERE plane_id="+str(plane_id)+") UPDATE repairs.planes SET new_value=(SELECT "+column+" FROM new_values) WHERE repair_id=LASTVAL();\n"); # insert the new repair row with the old values
+
+# first get the old values from qc.planes and create a new row in repairs.planes
+if (panel_swap_out != None):
+    for panel_out,panel_in,panel_pos in zip(panel_swap_out,panel_swap_in,panel_swap_pos): # need to do these together
+#        print(panel_out,panel_in,panel_pos)
+
+        column="panel_id_pos"+str(panel_pos)
+        update_sql_file.write("WITH old_values AS (SELECT plane_id,"+column+" from qc.planes WHERE plane_id="+str(plane_id)+") INSERT INTO repairs.planes(plane_id, old_value) SELECT plane_id,"+column+" FROM old_values;\n"); # insert the new repair row with the old values
+
+        # make changes to qc.planes
+        update_sql_file.write("UPDATE qc.planes SET "+column+"="+panel_in+" where plane_id=" + str(plane_id) + ";\n");
+
+        # now update repairs table
+        update_sql_file.write("UPDATE repairs.planes SET column_changed=\'"+column+"\',date_uploaded=\'"+date.today().strftime('%Y-%m-%d')+"\',comment=\'"+comment+"\' where repair_id=LASTVAL();\n") # now add the changed column and comment
+        update_sql_file.write("WITH new_values AS (SELECT plane_id,"+column+" from qc.planes WHERE plane_id="+str(plane_id)+") UPDATE repairs.planes SET new_value=(SELECT "+column+" FROM new_values) WHERE repair_id=LASTVAL();\n"); # insert the new repair row with the old values
+
+
+
 
 
 print("Done!");

--- a/sql/create_planes_table.sql
+++ b/sql/create_planes_table.sql
@@ -2,7 +2,12 @@ set role mu2e_tracker_admin;
 
 create table qc.planes (
 	plane_id integer primary key,
-	panel_ids integer[] NULL
+	panel_id_pos0 integer NULL,
+	panel_id_pos1 integer NULL,
+	panel_id_pos2 integer NULL,
+	panel_id_pos3 integer NULL,
+	panel_id_pos4 integer NULL,
+	panel_id_pos5 integer NULL
 );
 
 grant select on qc.planes to public;


### PR DESCRIPTION
Previously had one column with an array of 6 elements. I've updated the viewer, python scripts, etc. Note that the viewer still handles both the six-column format and the one-column format since we will need to convert data to the new format.