### PR TITLE
Add permissions on qc.planes table

### DIFF
--- a/sql/create_planes_table.sql
+++ b/sql/create_planes_table.sql
@@ -14,3 +14,5 @@ create table qc.planes (
 
 grant select on qc.planes to public;
 grant insert on qc.planes to mu2e_tracker_admin;
+grant insert on qc.planes to mu2e_tracker_writer;
+grant update on qc.planes to mu2e_tracker_writer;


### PR DESCRIPTION
Permissions were added by hand. I've just documented the commands in the create table.sql so that we have them in future